### PR TITLE
Remove upload of cache and edge images on PR

### DIFF
--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -208,7 +208,7 @@ jobs:
           platforms: linux/${{ env.ARCH }}
           provenance: false #https://github.com/orgs/community/discussions/45969#discussioncomment-4852744
           sbom: false
-          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
+          push: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'pull_request' }}
           load: true
           tags: |
             ${{ env.GHCR_IMAGE }}:edge-${{ env.ARCH }}
@@ -259,7 +259,7 @@ jobs:
           platforms: linux/${{ env.ARCH }}
           provenance: false #https://github.com/orgs/community/discussions/45969#discussioncomment-4852744
           sbom: false
-          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
+          push: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'pull_request' }}
           load: true
           tags: |
             ${{ env.GHCR_IMAGE }}:edge-${{ env.ARCH }}

--- a/.github/workflows/test-build-binaries.yml
+++ b/.github/workflows/test-build-binaries.yml
@@ -187,7 +187,13 @@ jobs:
       - name: Lowercase repository owner
         id: repo
         run: |
-          echo "GHCR_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
+          GHCR_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${IMAGE_NAME}"
+          echo "GHCR_IMAGE=${GHCR_IMAGE}" >> $GITHUB_ENV
+          if [[ "${GITHUB_REF}" == "refs/heads/main" || "${GITHUB_REF}" == refs/tags/v* ]] && [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+            echo "DOCKER_CACHE_TO=type=registry,ref=${GHCR_IMAGE}:cache-${ARCH},mode=max" >> $GITHUB_ENV
+          else
+            echo "DOCKER_CACHE_TO=" >> $GITHUB_ENV
+          fi
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -202,14 +208,24 @@ jobs:
           platforms: linux/${{ env.ARCH }}
           provenance: false #https://github.com/orgs/community/discussions/45969#discussioncomment-4852744
           sbom: false
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
+          load: true
           tags: |
             ${{ env.GHCR_IMAGE }}:edge-${{ env.ARCH }}
+            ${{ env.GHCR_IMAGE }}:edge-${{ env.ARCH }}-${{ github.sha }}
           cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}:cache-${{ env.ARCH }}
-          cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}:cache-${{ env.ARCH }},mode=max
+          cache-to: ${{ env.DOCKER_CACHE_TO }}
           build-args: |
             GITHUB_SHA=${{ github.sha }}
             IS_RELEASE=${{ startsWith(github.ref, 'refs/tags/') }}
+      - name: Save Docker image as artifact
+        run: |
+          docker save ${{ env.GHCR_IMAGE }}:edge-${{ env.ARCH }}-${{ github.sha }} -o image-${{ env.ARCH }}.tar
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-${{ env.ARCH }}
+          path: image-${{ env.ARCH }}.tar
 
   docker-build-arm64:
     name: Build arm64 edge and cache images
@@ -228,6 +244,7 @@ jobs:
         id: repo
         run: |
           echo "GHCR_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
+          echo "DOCKER_CACHE_TO=${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'pull_request' && format('type=registry,ref={0}:cache-{1},mode=max', env.GHCR_IMAGE, env.ARCH) || '' }}" >> $GITHUB_ENV
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -242,18 +259,56 @@ jobs:
           platforms: linux/${{ env.ARCH }}
           provenance: false #https://github.com/orgs/community/discussions/45969#discussioncomment-4852744
           sbom: false
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
+          load: true
           tags: |
             ${{ env.GHCR_IMAGE }}:edge-${{ env.ARCH }}
+            ${{ env.GHCR_IMAGE }}:edge-${{ env.ARCH }}-${{ github.sha }}
           cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}:cache-${{ env.ARCH }}
-          cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}:cache-${{ env.ARCH }},mode=max
+          cache-to: ${{ env.DOCKER_CACHE_TO }}
           build-args: |
             GITHUB_SHA=${{ github.sha }}
             IS_RELEASE=${{ startsWith(github.ref, 'refs/tags/') }}
+      - name: Save Docker image as artifact
+        run: |
+          docker save ${{ env.GHCR_IMAGE }}:edge-${{ env.ARCH }}-${{ github.sha }} -o image-${{ env.ARCH }}.tar
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-${{ env.ARCH }}
+          path: image-${{ env.ARCH }}.tar
 
-  docker-test-publish-manifests:
+  docker-test-amd64:
+    name: Test amd64 image
+    needs: [docker-build-amd64]
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ledfx
+      ARCH: amd64
+    steps:
+      - name: Lowercase repository owner
+        id: repo
+        run: |
+          echo "GHCR_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: image-${{ env.ARCH }}
+      - name: Load Docker image
+        run: docker load -i image-${{ env.ARCH }}.tar
+      - name: Run test container
+        run: |
+          docker run --rm ${{ env.GHCR_IMAGE }}:edge-${{ env.ARCH }}-${{ github.sha }} --ci-smoke-test -vv --offline
+          docker run --rm --entrypoint ledfx ${{ env.GHCR_IMAGE }}:edge-${{ env.ARCH }}-${{ github.sha }} --version | sed 's/LedFx //' > ledfx_version_docker.txt
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ledfx_version_docker
+          path: ledfx_version_docker.txt
+
+  docker-publish:
     name: Test amd64 and Publish image
-    needs: [docker-build-amd64, docker-build-arm64]
+    needs: [docker-build-amd64, docker-build-arm64, docker-test-amd64]
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: ledfx
@@ -271,28 +326,22 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Create multiarch image manifest for edge
-      #   run: |
-      #     docker buildx imagetools create \
-      #       --tag ${{ env.GHCR_IMAGE }}:edge \
-      #       ${{ env.GHCR_IMAGE }}:edge-amd64 \
-      #       ${{ env.GHCR_IMAGE }}:edge-arm64
-      - name: Smoke test edge-amd64 image from registry
-        run: |
-          docker run --rm ${{ env.GHCR_IMAGE }}:edge-amd64 --ci-smoke-test -vv --offline
-      - name: Get LedFx version
+      - name: Download ledfx version docker txt
+        uses: actions/download-artifact@v4
+        with:
+          name: ledfx_version_docker
+      - name: Get LedFx Version
         id: ledfx-version
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          echo "ledfx-version=$(docker run --rm --entrypoint ledfx ${{ env.GHCR_IMAGE }}:edge-amd64 --version | sed 's/LedFx //')" >> $GITHUB_OUTPUT
+          echo "ledfx-version=$(cat ledfx_version_docker.txt)" >> $GITHUB_OUTPUT
       - name: Retag and push latest and versioned images if tag is same as ledfx-version
         if: github.ref == format('refs/tags/v{0}', steps.ledfx-version.outputs.ledfx-version)
         run: |
           docker buildx imagetools create \
             -t ${{ env.GHCR_IMAGE }}:latest \
             -t ${{ env.GHCR_IMAGE }}:${{ steps.ledfx-version.outputs.ledfx-version }} \
-            ${{ env.GHCR_IMAGE }}:edge-amd64 \
-            ${{ env.GHCR_IMAGE }}:edge-arm64
+            ${{ env.GHCR_IMAGE }}:edge-amd64-${{ github.sha }} \
+            ${{ env.GHCR_IMAGE }}:edge-arm64-${{ github.sha }}
 
   run-ledfx-windows:
     name: Test LedFx (Windows)


### PR DESCRIPTION
Changed github action to:
1. Upload cache and edge image only on commits to main, tagged version and not PR.
2. Use artifacts to move image from build stage to test stage.
3. Still allows using docker cache image from last successful image for speeding things up.